### PR TITLE
Add service account

### DIFF
--- a/confluentcloud/service_account.go
+++ b/confluentcloud/service_account.go
@@ -57,7 +57,7 @@ func (c *Client) CreateServiceAccount(request *ServiceAccountCreateRequest) (*Se
 	return &response.Result().(*ServiceAccountResponse).ServiceAccount, nil
 }
 
-func (c *Client) ListServiceAccounts(clusterID, accountID string) ([]ServiceAccount, error) {
+func (c *Client) ListServiceAccounts() ([]ServiceAccount, error) {
 	rel, err := url.Parse("service_accounts")
 	if err != nil {
 		return []ServiceAccount{}, err
@@ -65,8 +65,6 @@ func (c *Client) ListServiceAccounts(clusterID, accountID string) ([]ServiceAcco
 
 	u := c.BaseURL.ResolveReference(rel)
 	response, err := c.NewRequest().
-		SetQueryParam("account_id", accountID).
-		SetQueryParam("cluster_id", clusterID).
 		SetResult(&ServiceAccountsResponse{}).
 		SetError(&ErrorResponse{}).
 		Get(u.String())

--- a/confluentcloud/service_account.go
+++ b/confluentcloud/service_account.go
@@ -1,0 +1,110 @@
+package confluentcloud
+
+import (
+	"fmt"
+	"net/url"
+)
+
+type ServiceAccount struct {
+	ID          int    `json:"id"`
+	Name        string `json:"service_name"`
+	Description string `json:"service_description"`
+}
+
+type ServiceAccountsResponse struct {
+	ServiceAccounts []ServiceAccount `json:"users"`
+}
+
+type ServiceAccountResponse struct {
+	ServiceAccount ServiceAccount `json:"user"`
+}
+type ServiceAccountCreateRequestW struct {
+	ServiceAccount *ServiceAccountCreateRequest `json:"user"`
+}
+type ServiceAccountCreateRequest struct {
+	Name        string `json:"service_name"`
+	Description string `json:"service_description"`
+}
+type ServiceAccountDeleteRequestW struct {
+	ServiceAccount ServiceAccountDeleteRequest `json:"user"`
+}
+type ServiceAccountDeleteRequest struct {
+	ID int `json:"id"`
+}
+
+func (c *Client) CreateServiceAccount(request *ServiceAccountCreateRequest) (*ServiceAccount, error) {
+	rel, err := url.Parse("service_accounts")
+	if err != nil {
+		return nil, err
+	}
+
+	u := c.BaseURL.ResolveReference(rel)
+
+	response, err := c.NewRequest().
+		SetBody(&ServiceAccountCreateRequestW{ServiceAccount: request}).
+		SetResult(&ServiceAccountResponse{}).
+		SetError(&ErrorResponse{}).
+		Post(u.String())
+
+	if err != nil {
+		return nil, err
+	}
+
+	if response.IsError() {
+		return nil, fmt.Errorf("service_accounts: %s", response.Error().(*ErrorResponse).Error.Message)
+	}
+
+	return &response.Result().(*ServiceAccountResponse).ServiceAccount, nil
+}
+
+func (c *Client) ListServiceAccounts(clusterID, accountID string) ([]ServiceAccount, error) {
+	rel, err := url.Parse("service_accounts")
+	if err != nil {
+		return []ServiceAccount{}, err
+	}
+
+	u := c.BaseURL.ResolveReference(rel)
+	response, err := c.NewRequest().
+		SetQueryParam("account_id", accountID).
+		SetQueryParam("cluster_id", clusterID).
+		SetResult(&ServiceAccountsResponse{}).
+		SetError(&ErrorResponse{}).
+		Get(u.String())
+
+	if err != nil {
+		return []ServiceAccount{}, err
+	}
+
+	if response.IsError() {
+		return []ServiceAccount{}, fmt.Errorf("service_accounts: %s", response.Error().(*ErrorResponse).Error.Message)
+	}
+	return response.Result().(*ServiceAccountsResponse).ServiceAccounts, nil
+}
+
+func (c *Client) DeleteServiceAccount(id int) error {
+	rel, err := url.Parse("service_accounts")
+	if err != nil {
+		return err
+	}
+
+	u := c.BaseURL.ResolveReference(rel)
+
+	request := ServiceAccountDeleteRequest{
+		ID: id,
+	}
+
+	response, err := c.NewRequest().
+		SetError(&ErrorResponse{}).
+		SetBody(&ServiceAccountDeleteRequestW{ServiceAccount: request}).
+		Delete(u.String())
+
+	if err != nil {
+		return err
+	}
+
+	if response.IsError() {
+		return fmt.Errorf("delete service account: %s", response.Error().(*ErrorResponse).Error.Message)
+	}
+
+	return nil
+}


### PR DESCRIPTION
This adds support for creating, listing and deleting service accounts. I'm not a Go developer, and I just got started working with Confluent Cloud, so let me know if something is wonky.

I tried creating, listing and deleting service accounts using this, and it worked fine for me. I basically enabled debug logging in the Confluent Cloud CLI to figure out what the requests should look like, although their client seems to send a lot of stuff that doesn't seem to be necessary or used. I just stuck to the subset that actually seemed to matter.