### PR TITLE
Including UserID to Api Key creation

### DIFF
--- a/confluentcloud/api_keys.go
+++ b/confluentcloud/api_keys.go
@@ -37,6 +37,7 @@ type ApiKeyCreateRequestW struct {
 }
 type ApiKeyCreateRequest struct {
 	AccountID       string           `json:"accountId"`
+	UserID          int              `json:"user_id,omitempty"`
 	LogicalClusters []LogicalCluster `json:"logical_clusters"`
 }
 


### PR DESCRIPTION
Hi,
I'm working with this module in Confluent Cloud terraform provider and I need to add user id information on API KEY creation. Without that the API KEY will be created to logged user id, which isn't my case.
Thanks a lot!