### PR TITLE
Add description to Create API key request

### DIFF
--- a/confluentcloud/api_keys.go
+++ b/confluentcloud/api_keys.go
@@ -38,6 +38,7 @@ type ApiKeyCreateRequestW struct {
 type ApiKeyCreateRequest struct {
 	AccountID       string           `json:"accountId"`
 	UserID          int              `json:"user_id,omitempty"`
+	Description     string           `json:"description,omitempty"`
 	LogicalClusters []LogicalCluster `json:"logical_clusters"`
 }
 


### PR DESCRIPTION
Add the description field to the create API request. 
I had the same need as this issue raised in the [terraform provider](https://github.com/Mongey/terraform-provider-confluentcloud/issues/25)

Let me know if there's anything else I should add
