### PR TITLE
Enable Schema Registry component

### DIFF
--- a/confluentcloud/schema_registry.go
+++ b/confluentcloud/schema_registry.go
@@ -1,0 +1,101 @@
+package confluentcloud
+
+import (
+	"fmt"
+	"net/url"
+)
+
+const schemaRegistryApiResource = "schema_registries?account_id=%s"
+
+type SchemaRegistryResponse struct {
+	Clusters []Cluster `json:"clusters"`
+}
+
+type SchemaRegistryCreateResponse struct {
+	Cluster Cluster `json:"cluster"`
+}
+
+type SchemaRegistryCreateRequest struct {
+	Config SchemaRegistryRequest `json:"config"`
+}
+
+type SchemaRegistryRequest struct {
+	AccountID           string `json:"account_id"`
+	KafkaClusterID		string `json:"kafka_cluster_id"`
+	Location			string `json:"location"`
+	Name				string `json:"name"`
+	ServiceProvider		string `json:"service_provider"`
+}
+
+func (c *Client) GetSchemaRegistries(id string) (*[]Cluster, error) {
+	rel, err := url.Parse(fmt.Sprintf(schemaRegistryApiResource, id))
+	if err != nil {
+		return nil, err
+	}
+
+	u := c.BaseURL.ResolveReference(rel)
+
+	response, err := c.NewRequest().
+		SetResult(&SchemaRegistryResponse{}).
+		SetError(&ErrorResponse{}).
+		Get(u.String())
+
+	if err != nil {
+		return nil, err
+	}
+ 
+	if response.IsError() {
+		return nil, fmt.Errorf("get environment: %s", response.Error().(*ErrorResponse).Error.Message)
+	}
+
+	return &response.Result().(*SchemaRegistryResponse).Clusters, nil
+}
+
+func (c *Client) CreateSchemaRegistry(accountID string, location string, serviceProvider string) (*Cluster, error) {
+	rel, err := url.Parse(fmt.Sprintf(schemaRegistryApiResource, accountID))
+	if err != nil {
+		return nil, err
+	}
+
+	kafka_clusters, err := c.ListClusters(accountID)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if len(kafka_clusters) == 0 {
+		return nil, fmt.Errorf("No cluster found. Cannot enable schema registry. Environment: %s", accountID)
+	}
+
+	u := c.BaseURL.ResolveReference(rel)
+
+	request := SchemaRegistryRequest{
+		KafkaClusterID: "",
+		Name: "account schema-registry",
+		AccountID: accountID,
+		Location: location,
+		ServiceProvider: serviceProvider,
+	}
+
+	response, err := c.NewRequest().
+		SetBody(&SchemaRegistryCreateRequest{Config: request}).
+		SetResult(&SchemaRegistryCreateResponse{}).
+		SetError(&ErrorResponse{}).
+		Post(u.String())
+
+	if err != nil {
+		return nil, err
+	}
+
+	if response.IsError() {
+		return nil, fmt.Errorf("Schema registry: %s", response.Error().(*ErrorResponse).Error.Message)
+	}
+
+	cluster := &response.Result().(*SchemaRegistryCreateResponse).Cluster
+
+	if cluster == nil {
+		return nil, fmt.Errorf("Schema registry not created. Environment: %s", accountID)
+	}
+
+	return cluster, nil
+}

--- a/confluentcloud/schema_registry.go
+++ b/confluentcloud/schema_registry.go
@@ -21,10 +21,10 @@ type SchemaRegistryCreateRequest struct {
 
 type SchemaRegistryRequest struct {
 	AccountID           string `json:"account_id"`
-	KafkaClusterID		string `json:"kafka_cluster_id"`
-	Location			string `json:"location"`
-	Name				string `json:"name"`
-	ServiceProvider		string `json:"service_provider"`
+	KafkaClusterID      string `json:"kafka_cluster_id"`
+	Location            string `json:"location"`
+	Name                string `json:"name"`
+	ServiceProvider     string `json:"service_provider"`
 }
 
 func (c *Client) GetSchemaRegistries(id string) (*[]Cluster, error) {

--- a/confluentcloud/schema_registry.go
+++ b/confluentcloud/schema_registry.go
@@ -3,16 +3,33 @@ package confluentcloud
 import (
 	"fmt"
 	"net/url"
+	"time"
 )
 
 const schemaRegistryApiResource = "schema_registries?account_id=%s"
 
+type SchemaRegistry struct {
+	ID                string    `json:"id"`
+	Name              string    `json:"name"`
+	KafkaClusterID    string    `json:"kafka_cluster_id"`
+	Endpoint          string    `json:"endpoint"`
+	Created           time.Time `json:"created"`
+	Modified          time.Time `json:"modified"`
+	Status            string    `json:"status"`
+	PhysicalClusterID string    `json:"physical_cluster_id"`
+	AccountID         string    `json:"account_id"`
+	OrganizationID    int       `json:"organization_id"`
+	MaxSchemas        int       `json:"max_schemas"`
+}
+
 type SchemaRegistryResponse struct {
-	Clusters []Cluster `json:"clusters"`
+	Error interface{}	   `json:"error"`
+	Clusters []SchemaRegistry `json:"clusters"`
 }
 
 type SchemaRegistryCreateResponse struct {
-	Cluster Cluster `json:"cluster"`
+	Error interface{}	   `json:"error"`
+	Cluster SchemaRegistry `json:"cluster"`
 }
 
 type SchemaRegistryCreateRequest struct {
@@ -27,7 +44,7 @@ type SchemaRegistryRequest struct {
 	ServiceProvider     string `json:"service_provider"`
 }
 
-func (c *Client) GetSchemaRegistries(id string) (*[]Cluster, error) {
+func (c *Client) GetSchemaRegistries(id string) ([]SchemaRegistry, error) {
 	rel, err := url.Parse(fmt.Sprintf(schemaRegistryApiResource, id))
 	if err != nil {
 		return nil, err
@@ -48,10 +65,10 @@ func (c *Client) GetSchemaRegistries(id string) (*[]Cluster, error) {
 		return nil, fmt.Errorf("get environment: %s", response.Error().(*ErrorResponse).Error.Message)
 	}
 
-	return &response.Result().(*SchemaRegistryResponse).Clusters, nil
+	return response.Result().(*SchemaRegistryResponse).Clusters, nil
 }
 
-func (c *Client) CreateSchemaRegistry(accountID string, location string, serviceProvider string) (*Cluster, error) {
+func (c *Client) CreateSchemaRegistry(accountID string, location string, serviceProvider string) (*SchemaRegistry, error) {
 	rel, err := url.Parse(fmt.Sprintf(schemaRegistryApiResource, accountID))
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Enable the ccloud schema registry component. 

The schema registry component can be enabled only if the environment contains at least one cluster. The change is irreversible, therefore, no delete/update functions has been introduced.
