### PR TITLE
Better error message handling for Connector creation

### DIFF
--- a/confluentcloud/connector.go
+++ b/confluentcloud/connector.go
@@ -78,7 +78,7 @@ func (c *Client) CreateConnector(account_id, cluster_id, name string, config Con
 	response, err := c.NewRequest().
 		SetBody(&CreateConnectorRequest{Name: name, Config: config}).
 		SetResult(&ConnectorInfo{}).
-		SetError(&ErrorResponse{}).
+		SetError(&ErrorMessage{}).
 		Post(u.String())
 
 	if err != nil {
@@ -86,7 +86,7 @@ func (c *Client) CreateConnector(account_id, cluster_id, name string, config Con
 	}
 
 	if response.IsError() {
-		return nil, fmt.Errorf("connectors: %s", response.Error().(*ErrorResponse).Error.Message)
+		return nil, fmt.Errorf("connectors: %s", response.Error().(*ErrorMessage).Message)
 	}
 
 	return response.Result().(*ConnectorInfo), nil


### PR DESCRIPTION
Interestingly, Confluent API does not return a JSON object with an "error" field containing the error message when e.g. a validation error occurs during creating connectors. Instead, only the fields "message" and "code" are present in the returned body.

To better examine the cause of an error, this change reflects this and extracts the error message from the "message" field instead.