### PR TITLE
Allow configuring debug logs when instantiating new client

### DIFF
--- a/confluentcloud/confluentcloud.go
+++ b/confluentcloud/confluentcloud.go
@@ -30,10 +30,10 @@ type ErrorResponse struct {
 	Error ErrorMessage `json:"error"`
 }
 
-func NewClient(email, password string) *Client {
+func NewClient(email, password string, debug bool) *Client {
 	baseURL, _ := url.Parse(defaultBaseURL)
 	client := resty.New()
-	client.SetDebug(true)
+	client.SetDebug(debug)
 	c := &Client{BaseURL: baseURL, email: email, password: password, UserAgent: userAgent}
 	c.client = client
 	return c


### PR DESCRIPTION
Hey :wave: 

Thanks for writing up this client. This is a tiny PR which updates the `NewClient()` function to accept an additional `debug bool` argument so we're not debug logging at all times. Unfortunately I wasn't able to make this change without breaking the API. 

Interested to hear your thoughts :smile: 