### PR TITLE
Fixes #14 Dedicated cluster network options and encryption key

### DIFF
--- a/confluentcloud/cluster.go
+++ b/confluentcloud/cluster.go
@@ -28,6 +28,7 @@ type ClusterCreateConfig struct {
 	Deployment          ClusterCreateDeploymentConfig `json:"deployment"`
 	Cku                 int                           `json:"cku"`
 	SelectedNetworkType string                        `json:"selected_network_type"`
+	EncryptionKeyID     string                        `json:"encryption_key_id"`
 }
 
 type ClusterCreateRequest struct {

--- a/confluentcloud/cluster.go
+++ b/confluentcloud/cluster.go
@@ -17,16 +17,17 @@ type ClusterCreateDeploymentConfig struct {
 }
 
 type ClusterCreateConfig struct {
-	Name            string                        `json:"name"`
-	AccountID       string                        `json:"accountId"`
-	Storage         int                           `json:"storage"`
-	NetworkIngress  int                           `json:"network_ingress"`
-	NetworkEgress   int                           `json:"network_egress"`
-	Region          string                        `json:"region"`
-	ServiceProvider string                        `json:"serviceProvider"`
-	Durability      string                        `json:"durability"`
-	Deployment      ClusterCreateDeploymentConfig `json:"deployment"`
-	Cku             int                           `json:"cku"`
+	Name                string                        `json:"name"`
+	AccountID           string                        `json:"accountId"`
+	Storage             int                           `json:"storage"`
+	NetworkIngress      int                           `json:"network_ingress"`
+	NetworkEgress       int                           `json:"network_egress"`
+	Region              string                        `json:"region"`
+	ServiceProvider     string                        `json:"serviceProvider"`
+	Durability          string                        `json:"durability"`
+	Deployment          ClusterCreateDeploymentConfig `json:"deployment"`
+	Cku                 int                           `json:"cku"`
+	SelectedNetworkType string                        `json:"selected_network_type"`
 }
 
 type ClusterCreateRequest struct {


### PR DESCRIPTION
Fixes #14.

- Expose option to define a dedicated cluster's network option (Internet, Private Link, VPC Peering)
- Expose option to define a dedicated cluster's encryption key

This was discovered by submitting a cluster creation request via https://confluent.cloud UI and inspecting the POST body to https://confluent.cloud/api/clusters. This is what the body looks like:

        {
          "config": {
            "name": "cluster_2",
            "account_id": "env-12345",
            "network_ingress": 100,
            "network_egress": 100,
            "storage": 500,
            "durability": "LOW",
            "region": "eu-west-1",
            "service_provider": "aws",
            "organization_id": 12345,
            "deployment": {
              "sku": "DEDICATED",
              "account_id": "env-12345"
            },
            "cku": 1,
            "selected_network_type": "PRIVATE_LINK",
            "encryption_key_id": "arn:aws:kms:eu-west-1:000000000000:key/0000000000000-1111-2222-333333333333"
          }
        }