### PR TITLE
Allow a pre-configured resty client instance to be injected

### DIFF
--- a/confluentcloud/confluentcloud.go
+++ b/confluentcloud/confluentcloud.go
@@ -31,11 +31,15 @@ type ErrorResponse struct {
 }
 
 func NewClient(email, password string) *Client {
+	rc := resty.New()
+	rc.SetDebug(true)
+	return NewClientWithRestyClient(email, password, rc)
+}
+
+func NewClientWithRestyClient(email, password string, restyClient *resty.Client) *Client {
 	baseURL, _ := url.Parse(defaultBaseURL)
-	client := resty.New()
-	client.SetDebug(true)
 	c := &Client{BaseURL: baseURL, email: email, password: password, UserAgent: userAgent}
-	c.client = client
+	c.client = restyClient
 	return c
 }
 


### PR DESCRIPTION
This change makes it possible for consumers of this module to take advantage of features of [go-resty/resty](https://github.com/go-resty/resty) that are currently inaccessible due to the fact that the `resty.Client` instance is inaccessible.

The specifi feature that I'm hoping to use is [retry support](https://github.com/go-resty/resty#retries), which requires clients wishing to opt-in to call the `SetRetry*` family of methods on the `resty.Client` instance. I'm also interested in using resty's [middleware](https://github.com/go-resty/resty#request-and-response-middleware) functionality.